### PR TITLE
fix null reference crash when getting localized name of player's own faction

### DIFF
--- a/vartsTradeGuild/src/dto/VartsDto.cs
+++ b/vartsTradeGuild/src/dto/VartsDto.cs
@@ -47,9 +47,9 @@ namespace vartsTradeGuild.src.dto
                 var hashSet = new HashSet<string>();
                 foreach (var vartsDto in All)
                 {
-                    hashSet.Add(
-                        LocalizedTextManager.GetTranslatedText(BannerlordConfig.Language, vartsDto.Faction.GetID())
-                    );
+                    var factionName = LocalizedTextManager.GetTranslatedText(BannerlordConfig.Language, vartsDto.Faction.GetID());
+                    if (factionName == null) factionName = vartsDto.Faction.ToString(); //if no localization exists (e.g. for player's faction name) default to untranslated string
+                    hashSet.Add(factionName);
                 }
 
                 var list = hashSet.ToList();


### PR DESCRIPTION
I experienced a crash in `DistinctFaction` when looking up the localized name for my own faction

I can share my savegame with you if you need it for debugging purposes.


Here was the stack trace...

```
Recorded Unhandled Exceptions:
  1. System.NullReferenceException: Object reference not set to an instance of an object.
       at vartsTradeGuild.src.dto.VartsDto.<>c.<get_DistinctFaction>b__13_0(String o) in C:\okan\git\bannerlord-vartsTradeGuild\vartsTradeGuild\src\dto\VartsDto.cs:line 56
       at System.Linq.EnumerableSorter`2.ComputeKeys(TElement[] elements, Int32 count)
       at System.Linq.EnumerableSorter`1.Sort(TElement[] elements, Int32 count)
       at System.Linq.OrderedEnumerable`1.<GetEnumerator>d__1.MoveNext()
       at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
       at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
       at vartsTradeGuild.src.dto.VartsDto.get_DistinctFaction() in C:\okan\git\bannerlord-vartsTradeGuild\vartsTradeGuild\src\dto\VartsDto.cs:line 56
       at vartsTradeGuild.src.encyclopedia.DefaultEncyclopediaVartsPage..ctor() in C:\okan\git\bannerlord-vartsTradeGuild\vartsTradeGuild\src\encyclopedia\DefaultEncyclopediaVartsPage.cs:line 75
       at vartsTradeGuild.src.harmony.EncyclopediaManagerCreateEncyclopediaPagesPatch.Postfix(EncyclopediaManager __instance) in C:\okan\git\bannerlord-vartsTradeGuild\vartsTradeGuild\src\harmony\EncyclopediaManagerCreateEncyclopediaPagesPatch.cs:line 16
       at SandBox.SandBoxSubModule.OnGameInitializationFinished(Game game)
       at TaleWorlds.MountAndBlade.MBGameManager.OnGameInitializationFinished(Game game)
       at TaleWorlds.CampaignSystem.Campaign.OnInitialize()
       at TaleWorlds.CampaignSystem.Campaign.DoLoadingForGameType(GameTypeLoadingStates gameTypeLoadingState, GameTypeLoadingStates& nextState)
       at StoryMode.CampaignStoryMode.DoLoadingForGameType(GameTypeLoadingStates gameTypeLoadingState, GameTypeLoadingStates& nextState)
       at TaleWorlds.Core.GameType.DoLoadingForGameType()
       at SandBox.CampaignGameManager.DoLoadingForGameManager(GameManagerLoadingSteps gameManagerLoadingStep, GameManagerLoadingSteps& nextStep)
       at TaleWorlds.Core.GameManagerBase.DoLoadingForGameManager()
       at TaleWorlds.MountAndBlade.GameLoadingState.OnTick(Single dt)
       at TaleWorlds.Core.GameStateManager.OnTick(Single dt)
       at DMD<DMD<OnApplicationTick_Patch1>?42945014::OnApplicationTick_Patch1>(Module this, Single dt)
       at TaleWorlds.DotNet.Managed.ApplicationTick(Single dt)
       at DMD<DMD<Managed_ApplicationTick_Patch1>?30364822::Managed_ApplicationTick_Patch1>(Single dt)
```


When debugging, I discovered that I got a null result when the code tries to grab the localized version of my own clan's name (Praxos is the name of my player faction).

![image](https://user-images.githubusercontent.com/6412918/79300701-77a98480-7eb5-11ea-9d03-ba7fcc9852e5.png)
